### PR TITLE
fixed canvas init, added temp text tool cursor

### DIFF
--- a/data/ui/gnome_paint.ui
+++ b/data/ui/gnome_paint.ui
@@ -1,85 +1,96 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy toplevel-contextual -->
   <object class="GtkWindow" id="window">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="default_width">640</property>
     <property name="default_height">480</property>
-    <signal name="destroy" handler="on_window_destroy"/>
-    <signal name="delete_event" handler="on_window_delete_event"/>
+    <signal name="destroy" handler="on_window_destroy" swapped="no"/>
+    <signal name="delete-event" handler="on_window_delete_event" swapped="no"/>
     <child>
       <object class="GtkVBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <child>
           <object class="GtkMenuBar" id="menu">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkMenuItem" id="menuitem-file">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">_File</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu-file">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="tearoff_title">File</property>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-new">
                         <property name="label">gtk-new</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="n" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_new_activate"/>
+                        <signal name="activate" handler="on_menu_new_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-open">
                         <property name="label">gtk-open</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="o" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_open_activate"/>
+                        <signal name="activate" handler="on_menu_open_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-save">
                         <property name="label">gtk-save</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_save_activate"/>
+                        <signal name="activate" handler="on_menu_save_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-save-as">
                         <property name="label">gtk-save-as</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="s" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_save_as_activate"/>
+                        <signal name="activate" handler="on_menu_save_as_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem1">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-quit">
                         <property name="label">gtk-quit</property>
                         <property name="visible">True</property>
-                        <property name="events"></property>
+                        <property name="can_focus">False</property>
+                        <property name="events"/>
                         <property name="extension_events">all</property>
                         <property name="has_tooltip">True</property>
                         <property name="border_width">2</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="q" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_window_destroy"/>
+                        <signal name="activate" handler="on_window_destroy" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -89,40 +100,46 @@
             <child>
               <object class="GtkMenuItem" id="menuitem-edit">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">_Edit</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu2">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-undo">
                         <property name="label">gtk-undo</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="z" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_undo_activate"/>
+                        <signal name="activate" handler="on_menu_undo_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-redo">
                         <property name="label">gtk-redo</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="z" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_redo_activate"/>
+                        <signal name="activate" handler="on_menu_redo_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkSeparatorMenuItem" id="separator">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-cut">
                         <property name="label">gtk-cut</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="x" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -132,26 +149,29 @@
                       <object class="GtkImageMenuItem" id="menu-copy">
                         <property name="label">gtk-copy</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="c" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_copy_activate"/>
+                        <signal name="activate" handler="on_menu_copy_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-paste">
                         <property name="label">gtk-paste</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="v" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                        <signal name="activate" handler="on_menu_paste_activate"/>
+                        <signal name="activate" handler="on_menu_paste_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="menu-delete">
                         <property name="label">gtk-delete</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="Delete" signal="activate"/>
@@ -161,70 +181,51 @@
                 </child>
               </object>
             </child>
-            <!-- <child>
-              <object class="GtkMenuItem" id="menuitem3">
-                <property name="visible">True</property>
-                <property name="label" translatable="yes">_View</property>
-                <property name="use_underline">True</property>
-              </object>
-            </child> -->
             <child>
               <object class="GtkMenuItem" id="menuitem5">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">_Image</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu1">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkMenuItem" id="menu_flip_rotate">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">_Flip/Rotate...</property>
                         <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_menu_flip_rotate_activate"/>
+                        <signal name="activate" handler="on_menu_flip_rotate_activate" swapped="no"/>
                       </object>
-                    </child>
-                    <child>
-                      <!--
-                      <object class="GtkMenuItem" id="menu_stretch_skew">
-                        <property name="visible">True</property>
-                        <property name="label" translatable="yes">_Stretch/Skew...</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_menu_stretch_skew_activate"/>
-                      </object>
-                      -->
                     </child>
                     <child>
                       <object class="GtkMenuItem" id="menu_invert_colors">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">_Invert Colors</property>
                         <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_menu_invert_colors_activate"/>
+                        <signal name="activate" handler="on_menu_invert_colors_activate" swapped="no"/>
                       </object>
                     </child>
-                    <!-- <child>
-                      <object class="GtkMenuItem" id="menu_attributes">
-                        <property name="visible">True</property>
-                        <property name="label" translatable="yes">_Attributes...</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_menu_attributes_activate"/>
-                      </object>
-                    </child> -->
                     <child>
                       <object class="GtkMenuItem" id="menu_clear_image">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">_Clear Image</property>
                         <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_menu_clear_image_activate"/>
+                        <signal name="activate" handler="on_menu_clear_image_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkCheckMenuItem" id="menu_draw_opaque">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">_Draw Opaque</property>
                         <property name="use_underline">True</property>
                         <property name="active">True</property>
-                        <signal name="toggled" handler="on_menu_draw_opaque_activate"/>
+                        <signal name="toggled" handler="on_menu_draw_opaque_activate" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -234,18 +235,21 @@
             <child>
               <object class="GtkMenuItem" id="menuitem_help">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">_Help</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu_help">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="menu_about">
                         <property name="label">gtk-about</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
-                        <signal name="activate" handler="on_menu_about_activate"/>
+                        <signal name="activate" handler="on_menu_about_activate" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -255,27 +259,33 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkHBox" id="hbox2">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkHandleBox" id="handlebox1">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="handle_position">top</property>
                 <property name="snap_edge_set">True</property>
                 <child>
                   <object class="GtkVBox" id="vbox3">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkHBox" id="hbox1">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="homogeneous">True</property>
                         <child>
                           <object class="GtkToolbar" id="toolbar1">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <property name="show_arrow">False</property>
                             <property name="tooltips">False</property>
@@ -286,7 +296,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="tooltip_text" translatable="yes">Free select tool</property>
                                 <property name="icon_name">stock-tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_free_select_toggled"/>
+                                <signal name="toggled" handler="on_tool_free_select_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -299,7 +309,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-eraser</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_eraser_toggled"/>
+                                <signal name="toggled" handler="on_tool_eraser_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -312,7 +322,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-color-picker</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_color_picker_toggled"/>
+                                <signal name="toggled" handler="on_tool_color_picker_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -325,8 +335,8 @@
                                 <property name="icon_name">stock-tool-pencil</property>
                                 <property name="active">True</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="realize" handler="on_tool_pencil_realize"/>
-                                <signal name="toggled" handler="on_tool_pencil_toggled"/>
+                                <signal name="toggled" handler="on_tool_pencil_toggled" swapped="no"/>
+                                <signal name="realize" handler="on_tool_pencil_realize" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -339,7 +349,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-airbrush</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_airbrush_toggled"/>
+                                <signal name="toggled" handler="on_tool_airbrush_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -352,7 +362,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock_draw-line</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_draw_line_toggled"/>
+                                <signal name="toggled" handler="on_draw_line_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -365,7 +375,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock_draw-rectangle</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_draw_rectangle_toggled"/>
+                                <signal name="toggled" handler="on_draw_rectangle_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -378,7 +388,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock_draw-ellipse</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_draw_ellipse_toggled"/>
+                                <signal name="toggled" handler="on_draw_ellipse_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -387,6 +397,7 @@
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
                             <property name="fill">False</property>
                             <property name="position">0</property>
                           </packing>
@@ -394,6 +405,7 @@
                         <child>
                           <object class="GtkToolbar" id="toolbar2">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <property name="show_arrow">False</property>
                             <property name="tooltips">False</property>
@@ -405,7 +417,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-rect-select</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_rect_select_toggled"/>
+                                <signal name="toggled" handler="on_tool_rect_select_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -418,7 +430,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-bucket-fill</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_bucket_fill_toggled"/>
+                                <signal name="toggled" handler="on_tool_bucket_fill_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -431,7 +443,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-zoom</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_zoom_toggled"/>
+                                <signal name="toggled" handler="on_tool_zoom_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -444,7 +456,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-paintbrush</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_paintbrush_toggled"/>
+                                <signal name="toggled" handler="on_tool_paintbrush_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -457,7 +469,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock-tool-text</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_tool_text_toggled"/>
+                                <signal name="toggled" handler="on_tool_text_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -470,7 +482,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock_draw-curve</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_draw_curve_toggled"/>
+                                <signal name="toggled" handler="on_draw_curve_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -483,7 +495,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock_draw-fill_polygon</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_draw_polygon_toggled"/>
+                                <signal name="toggled" handler="on_draw_polygon_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -496,7 +508,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="icon_name">stock_draw-rounded-rectangle</property>
                                 <property name="group">tool-free-select</property>
-                                <signal name="toggled" handler="on_draw_rounded_rectangle_toggled"/>
+                                <signal name="toggled" handler="on_draw_rounded_rectangle_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -505,6 +517,7 @@
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
                             <property name="fill">False</property>
                             <property name="position">1</property>
                           </packing>
@@ -518,15 +531,17 @@
                     </child>
                     <child>
                       <object class="GtkNotebook" id="notebook">
+                        <property name="can_focus">False</property>
                         <property name="show_tabs">False</property>
                         <property name="show_border">False</property>
                         <property name="tab_border">0</property>
                         <property name="tab_hborder">0</property>
                         <property name="tab_vborder">0</property>
-                        <signal name="realize" handler="on_notebook_realize"/>
+                        <signal name="realize" handler="on_notebook_realize" swapped="no"/>
                         <child>
                           <object class="GtkVBox" id="tab_none">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <placeholder/>
                             </child>
@@ -538,24 +553,28 @@
                         <child>
                           <object class="GtkVBox" id="tab_selection">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame1">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="border_width">2</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkToolbar" id="toolbar5">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <property name="show_arrow">False</property>
                                     <property name="icon_size">1</property>
                                     <property name="icon_size_set">True</property>
                                     <child>
                                       <object class="GtkRadioToolButton" id="sel1">
+                                        <property name="can_focus">False</property>
                                         <property name="active">True</property>
-                                        <signal name="realize" handler="on_sel1_realize"/>
-                                        <signal name="toggled" handler="on_sel1_toggled"/>
+                                        <signal name="toggled" handler="on_sel1_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_sel1_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -564,9 +583,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="sel2">
+                                        <property name="can_focus">False</property>
                                         <property name="group">sel1</property>
-                                        <signal name="realize" handler="on_sel2_realize"/>
-                                        <signal name="toggled" handler="on_sel2_toggled"/>
+                                        <signal name="toggled" handler="on_sel2_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_sel2_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -594,24 +614,28 @@
                         <child>
                           <object class="GtkVBox" id="tab_rect_line">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame_rect">
+                                <property name="can_focus">False</property>
                                 <property name="border_width">2</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
-                                <signal name="realize" handler="on_frame_rect_realize"/>
+                                <signal name="realize" handler="on_frame_rect_realize" swapped="no"/>
                                 <child>
                                   <object class="GtkToolbar" id="toolbar4">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <property name="show_arrow">False</property>
                                     <property name="icon_size">1</property>
                                     <property name="icon_size_set">True</property>
                                     <child>
                                       <object class="GtkRadioToolButton" id="rect0">
+                                        <property name="can_focus">False</property>
                                         <property name="active">True</property>
-                                        <signal name="realize" handler="on_rect0_realize"/>
-                                        <signal name="toggled" handler="on_rect0_toggled"/>
+                                        <signal name="toggled" handler="on_rect0_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_rect0_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -620,9 +644,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="rect1">
+                                        <property name="can_focus">False</property>
                                         <property name="group">rect0</property>
-                                        <signal name="realize" handler="on_rect1_realize"/>
-                                        <signal name="toggled" handler="on_rect1_toggled"/>
+                                        <signal name="toggled" handler="on_rect1_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_rect1_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -631,9 +656,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="rect2">
+                                        <property name="can_focus">False</property>
                                         <property name="group">rect0</property>
-                                        <signal name="realize" handler="on_rect2_realize"/>
-                                        <signal name="toggled" handler="on_rect2_toggled"/>
+                                        <signal name="toggled" handler="on_rect2_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_rect2_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -652,21 +678,24 @@
                             <child>
                               <object class="GtkFrame" id="frame_line">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="border_width">2</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkToolbar" id="toolbar3">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <property name="show_arrow">False</property>
                                     <property name="icon_size">1</property>
                                     <property name="icon_size_set">True</property>
                                     <child>
                                       <object class="GtkRadioToolButton" id="line0">
+                                        <property name="can_focus">False</property>
                                         <property name="active">True</property>
-                                        <signal name="realize" handler="on_line0_realize"/>
-                                        <signal name="toggled" handler="on_line0_toggled"/>
+                                        <signal name="toggled" handler="on_line0_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_line0_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -675,9 +704,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="line1">
+                                        <property name="can_focus">False</property>
                                         <property name="group">line0</property>
-                                        <signal name="realize" handler="on_line1_realize"/>
-                                        <signal name="toggled" handler="on_line1_toggled"/>
+                                        <signal name="toggled" handler="on_line1_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_line1_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -686,9 +716,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="line2">
+                                        <property name="can_focus">False</property>
                                         <property name="group">line0</property>
-                                        <signal name="realize" handler="on_line2_realize"/>
-                                        <signal name="toggled" handler="on_line2_toggled"/>
+                                        <signal name="toggled" handler="on_line2_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_line2_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -697,9 +728,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="line3">
+                                        <property name="can_focus">False</property>
                                         <property name="group">line0</property>
-                                        <signal name="realize" handler="on_line3_realize"/>
-                                        <signal name="toggled" handler="on_line3_toggled"/>
+                                        <signal name="toggled" handler="on_line3_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_line3_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -708,9 +740,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="line4">
+                                        <property name="can_focus">False</property>
                                         <property name="group">line0</property>
-                                        <signal name="realize" handler="on_line4_realize"/>
-                                        <signal name="toggled" handler="on_line4_toggled"/>
+                                        <signal name="toggled" handler="on_line4_toggled" swapped="no"/>
+                                        <signal name="realize" handler="on_line4_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -738,23 +771,27 @@
                         <child>
                           <object class="GtkVBox" id="tab_erase">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame7">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="border_width">2</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkToolbar" id="toolbar6">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <property name="show_arrow">False</property>
                                     <property name="icon_size">1</property>
                                     <property name="icon_size_set">True</property>
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase0">
+                                        <property name="can_focus">False</property>
                                         <property name="active">True</property>
-                                        <signal name="realize" handler="on_erase0_realize"/>
+                                        <signal name="realize" handler="on_erase0_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -763,8 +800,9 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase1">
+                                        <property name="can_focus">False</property>
                                         <property name="group">erase0</property>
-                                        <signal name="realize" handler="on_erase1_realize"/>
+                                        <signal name="realize" handler="on_erase1_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -773,8 +811,9 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase2">
+                                        <property name="can_focus">False</property>
                                         <property name="group">erase0</property>
-                                        <signal name="realize" handler="on_erase2_realize"/>
+                                        <signal name="realize" handler="on_erase2_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -783,8 +822,9 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase3">
+                                        <property name="can_focus">False</property>
                                         <property name="group">erase0</property>
-                                        <signal name="realize" handler="on_erase3_realize"/>
+                                        <signal name="realize" handler="on_erase3_realize" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -811,21 +851,25 @@
                         <child>
                           <object class="GtkVBox" id="tab_zoom">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame33">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="border_width">2</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkToolbar" id="toolbar7">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <property name="show_arrow">False</property>
                                     <property name="icon_size">1</property>
                                     <property name="icon_size_set">True</property>
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom0">
+                                        <property name="can_focus">False</property>
                                         <property name="active">True</property>
                                       </object>
                                       <packing>
@@ -835,6 +879,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom1">
+                                        <property name="can_focus">False</property>
                                         <property name="group">zoom0</property>
                                       </object>
                                       <packing>
@@ -844,6 +889,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom2">
+                                        <property name="can_focus">False</property>
                                         <property name="group">zoom0</property>
                                       </object>
                                       <packing>
@@ -853,6 +899,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom3">
+                                        <property name="can_focus">False</property>
                                         <property name="group">zoom0</property>
                                       </object>
                                       <packing>
@@ -880,24 +927,29 @@
                         <child>
                           <object class="GtkVBox" id="tab_brush">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame34">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="border_width">2</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkVBox" id="vbox4">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <child>
                                       <object class="GtkToolbar" id="tb_brush0">
+                                        <property name="can_focus">False</property>
                                         <property name="show_arrow">False</property>
                                         <property name="icon_size">1</property>
                                         <property name="icon_size_set">True</property>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush0">
+                                            <property name="can_focus">False</property>
                                             <property name="active">True</property>
-                                            <signal name="realize" handler="on_brush0_realize"/>
+                                            <signal name="realize" handler="on_brush0_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -906,8 +958,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush1">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush1_realize"/>
+                                            <signal name="realize" handler="on_brush1_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -916,8 +969,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush2">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush2_realize"/>
+                                            <signal name="realize" handler="on_brush2_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -934,14 +988,16 @@
                                     <child>
                                       <object class="GtkToolbar" id="toolbar10">
                                         <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
                                         <property name="show_arrow">False</property>
                                         <property name="icon_size">1</property>
                                         <property name="icon_size_set">True</property>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush3">
+                                            <property name="can_focus">False</property>
                                             <property name="active">True</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush3_realize"/>
+                                            <signal name="realize" handler="on_brush3_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -950,8 +1006,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush4">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush4_realize"/>
+                                            <signal name="realize" handler="on_brush4_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -960,8 +1017,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush5">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush5_realize"/>
+                                            <signal name="realize" handler="on_brush5_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -971,19 +1029,22 @@
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
+                                        <property name="fill">True</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkToolbar" id="toolbar11">
                                         <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
                                         <property name="show_arrow">False</property>
                                         <property name="icon_size">1</property>
                                         <property name="icon_size_set">True</property>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush6">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush6_realize"/>
+                                            <signal name="realize" handler="on_brush6_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -992,8 +1053,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush7">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush7_realize"/>
+                                            <signal name="realize" handler="on_brush7_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -1002,8 +1064,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush8">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush8_realize"/>
+                                            <signal name="realize" handler="on_brush8_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -1013,19 +1076,22 @@
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
+                                        <property name="fill">True</property>
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkToolbar" id="toolbar12">
                                         <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
                                         <property name="show_arrow">False</property>
                                         <property name="icon_size">1</property>
                                         <property name="icon_size_set">True</property>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush9">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush9_realize"/>
+                                            <signal name="realize" handler="on_brush9_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -1034,8 +1100,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush10">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush10_realize"/>
+                                            <signal name="realize" handler="on_brush10_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -1044,8 +1111,9 @@
                                         </child>
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush11">
+                                            <property name="can_focus">False</property>
                                             <property name="group">brush0</property>
-                                            <signal name="realize" handler="on_brush11_realize"/>
+                                            <signal name="realize" handler="on_brush11_realize" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
@@ -1055,6 +1123,7 @@
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
+                                        <property name="fill">True</property>
                                         <property name="position">3</property>
                                       </packing>
                                     </child>
@@ -1078,21 +1147,25 @@
                         <child>
                           <object class="GtkVBox" id="tab_spray">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame35">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="border_width">2</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkToolbar" id="toolbar8">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <property name="show_arrow">False</property>
                                     <property name="icon_size">1</property>
                                     <property name="icon_size_set">True</property>
                                     <child>
                                       <object class="GtkRadioToolButton" id="spray0">
+                                        <property name="can_focus">False</property>
                                         <property name="active">True</property>
                                       </object>
                                       <packing>
@@ -1102,6 +1175,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="spray1">
+                                        <property name="can_focus">False</property>
                                         <property name="group">spray0</property>
                                       </object>
                                       <packing>
@@ -1111,6 +1185,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioToolButton" id="spray2">
+                                        <property name="can_focus">False</property>
                                         <property name="group">spray0</property>
                                       </object>
                                       <packing>
@@ -1154,6 +1229,7 @@
             <child>
               <object class="GtkVBox" id="vbox2">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scl_wnd">
                     <property name="can_focus">True</property>
@@ -1162,45 +1238,27 @@
                     <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkViewport" id="cv_vp">
+                        <property name="can_focus">False</property>
                         <property name="events">GDK_EXPOSURE_MASK | GDK_STRUCTURE_MASK</property>
                         <property name="resize_mode">queue</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkEventBox" id="cv_ev_box">
-                            <signal name="expose_event" handler="on_cv_ev_box_expose_event"/>
-                            <signal name="realize" handler="on_cv_ev_box_realize"/>
+                            <property name="can_focus">False</property>
+                            <signal name="expose-event" handler="on_cv_ev_box_expose_event" swapped="no"/>
+                            <signal name="realize" handler="on_cv_ev_box_realize" swapped="no"/>
                             <child>
                               <object class="GtkTable" id="table1">
+                                <property name="can_focus">False</property>
                                 <property name="n_rows">3</property>
                                 <property name="n_columns">3</property>
-                                <child>
-                                  <object class="GtkDrawingArea" id="cv_drawing">
-                                    <property name="width_request">300</property>
-                                    <property name="height_request">300</property>
-                                    <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_STRUCTURE_MASK</property>
-                                    <signal name="expose_event" handler="on_cv_drawing_expose_event"/>
-                                    <signal name="unrealize" handler="on_cv_drawing_unrealize"/>
-                                    <signal name="button_press_event" handler="on_cv_drawing_button_press_event"/>
-                                    <signal name="realize" handler="on_cv_drawing_realize"/>
-                                    <signal name="leave_notify_event" handler="on_cv_drawing_leave_notify_event"/>
-                                    <signal name="motion_notify_event" handler="on_cv_drawing_motion_notify_event"/>
-                                    <signal name="button_release_event" handler="on_cv_drawing_button_release_event"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
-                                  </packing>
-                                </child>
                                 <child>
                                   <object class="GtkDrawingArea" id="cv_top_left">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
-                                    <signal name="expose_event" handler="on_cv_other_edge_expose_event"/>
-                                    <signal name="realize" handler="on_cv_other_edge_realize"/>
+                                    <property name="can_focus">False</property>
+                                    <signal name="expose-event" handler="on_cv_other_edge_expose_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_other_edge_realize" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="x_options">GTK_SHRINK</property>
@@ -1211,8 +1269,9 @@
                                   <object class="GtkDrawingArea" id="cv_top">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
-                                    <signal name="expose_event" handler="on_cv_other_edge_expose_event"/>
-                                    <signal name="realize" handler="on_cv_top_realize"/>
+                                    <property name="can_focus">False</property>
+                                    <signal name="expose-event" handler="on_cv_other_edge_expose_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_top_realize" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>
@@ -1225,8 +1284,9 @@
                                   <object class="GtkDrawingArea" id="cv_top_right">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
-                                    <signal name="expose_event" handler="on_cv_other_edge_expose_event"/>
-                                    <signal name="realize" handler="on_cv_other_edge_realize"/>
+                                    <property name="can_focus">False</property>
+                                    <signal name="expose-event" handler="on_cv_other_edge_expose_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_other_edge_realize" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="left_attach">2</property>
@@ -1239,11 +1299,12 @@
                                   <object class="GtkDrawingArea" id="cv_right">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
+                                    <property name="can_focus">False</property>
                                     <property name="events">GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-                                    <signal name="button_press_event" handler="on_cv_right_button_press_event"/>
-                                    <signal name="motion_notify_event" handler="on_cv_right_motion_notify_event"/>
-                                    <signal name="realize" handler="on_cv_right_realize"/>
-                                    <signal name="button_release_event" handler="on_cv_right_button_release_event"/>
+                                    <signal name="button-press-event" handler="on_cv_right_button_press_event" swapped="no"/>
+                                    <signal name="button-release-event" handler="on_cv_right_button_release_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_right_realize" swapped="no"/>
+                                    <signal name="motion-notify-event" handler="on_cv_right_motion_notify_event" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="left_attach">2</property>
@@ -1258,11 +1319,12 @@
                                   <object class="GtkDrawingArea" id="cv_bottom_right">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
+                                    <property name="can_focus">False</property>
                                     <property name="events">GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-                                    <signal name="button_press_event" handler="on_cv_bottom_right_button_press_event"/>
-                                    <signal name="motion_notify_event" handler="on_cv_bottom_right_motion_notify_event"/>
-                                    <signal name="realize" handler="on_cv_bottom_right_realize"/>
-                                    <signal name="button_release_event" handler="on_cv_bottom_right_button_release_event"/>
+                                    <signal name="button-press-event" handler="on_cv_bottom_right_button_press_event" swapped="no"/>
+                                    <signal name="button-release-event" handler="on_cv_bottom_right_button_release_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_bottom_right_realize" swapped="no"/>
+                                    <signal name="motion-notify-event" handler="on_cv_bottom_right_motion_notify_event" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="left_attach">2</property>
@@ -1277,11 +1339,12 @@
                                   <object class="GtkDrawingArea" id="cv_bottom">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
+                                    <property name="can_focus">False</property>
                                     <property name="events">GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-                                    <signal name="motion_notify_event" handler="on_cv_bottom_motion_notify_event"/>
-                                    <signal name="button_press_event" handler="on_cv_bottom_button_press_event"/>
-                                    <signal name="realize" handler="on_cv_bottom_realize"/>
-                                    <signal name="button_release_event" handler="on_cv_bottom_button_release_event"/>
+                                    <signal name="button-press-event" handler="on_cv_bottom_button_press_event" swapped="no"/>
+                                    <signal name="button-release-event" handler="on_cv_bottom_button_release_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_bottom_realize" swapped="no"/>
+                                    <signal name="motion-notify-event" handler="on_cv_bottom_motion_notify_event" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>
@@ -1296,8 +1359,9 @@
                                   <object class="GtkDrawingArea" id="cv_bottom_left">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
-                                    <signal name="expose_event" handler="on_cv_other_edge_expose_event"/>
-                                    <signal name="realize" handler="on_cv_other_edge_realize"/>
+                                    <property name="can_focus">False</property>
+                                    <signal name="expose-event" handler="on_cv_other_edge_expose_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_other_edge_realize" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -1310,14 +1374,43 @@
                                   <object class="GtkDrawingArea" id="cv_left">
                                     <property name="width_request">3</property>
                                     <property name="height_request">3</property>
-                                    <signal name="expose_event" handler="on_cv_other_edge_expose_event"/>
-                                    <signal name="realize" handler="on_cv_left_realize"/>
+                                    <property name="can_focus">False</property>
+                                    <signal name="expose-event" handler="on_cv_other_edge_expose_event" swapped="no"/>
+                                    <signal name="realize" handler="on_cv_left_realize" swapped="no"/>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
                                     <property name="x_options">GTK_SHRINK</property>
                                     <property name="y_options">GTK_SHRINK</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkFixed" id="cv_fixed">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <signal name="realize" handler="on_cv_fixed_realize" swapped="no"/>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="cv_drawing">
+                                        <property name="can_focus">False</property>
+                                        <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_STRUCTURE_MASK</property>
+                                        <signal name="button-press-event" handler="on_cv_drawing_button_press_event" swapped="no"/>
+                                        <signal name="unrealize" handler="on_cv_drawing_unrealize" swapped="no"/>
+                                        <signal name="leave-notify-event" handler="on_cv_drawing_leave_notify_event" swapped="no"/>
+                                        <signal name="button-release-event" handler="on_cv_drawing_button_release_event" swapped="no"/>
+                                        <signal name="realize" handler="on_cv_drawing_realize" swapped="no"/>
+                                        <signal name="expose-event" handler="on_cv_drawing_expose_event" swapped="no"/>
+                                        <signal name="motion-notify-event" handler="on_cv_drawing_motion_notify_event" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="top_attach">1</property>
+                                    <property name="bottom_attach">2</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
                                   </packing>
                                 </child>
                               </object>
@@ -1328,17 +1421,21 @@
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkHandleBox" id="handlebox2">
+                    <property name="can_focus">False</property>
                     <property name="snap_edge">left</property>
                     <property name="snap_edge_set">True</property>
                     <child>
                       <object class="GtkAlignment" id="alignment2">
                         <property name="height_request">43</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0</property>
                         <property name="xscale">0</property>
@@ -1349,18 +1446,21 @@
                           <object class="GtkHBox" id="hbox3">
                             <property name="height_request">33</property>
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="extension_events">cursor</property>
                             <property name="spacing">1</property>
                             <child>
                               <object class="GtkFrame" id="frame2">
                                 <property name="width_request">33</property>
                                 <property name="height_request">33</property>
+                                <property name="can_focus">False</property>
                                 <property name="resize_mode">queue</property>
                                 <property name="label_xalign">0</property>
                                 <property name="shadow_type">in</property>
                                 <child>
                                   <object class="GtkFixed" id="fixed1">
                                     <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <child>
                                       <object class="GtkViewport" id="viewport3">
                                         <property name="width_request">16</property>
@@ -1374,8 +1474,8 @@
                                             <property name="can_focus">True</property>
                                             <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK | GDK_VISIBILITY_NOTIFY_MASK</property>
                                             <property name="extension_events">all</property>
-                                            <signal name="realize" handler="on_background_color_picker_realize"/>
-                                            <signal name="button_release_event" handler="on_background_color_picker_button_release_event"/>
+                                            <signal name="button-release-event" handler="on_background_color_picker_button_release_event" swapped="no"/>
+                                            <signal name="realize" handler="on_background_color_picker_realize" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -1397,8 +1497,8 @@
                                             <property name="can_focus">True</property>
                                             <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                             <property name="extension_events">all</property>
-                                            <signal name="realize" handler="on_foreground_color_picker_realize"/>
-                                            <signal name="button_release_event" handler="on_foreground_color_picker_button_release_event"/>
+                                            <signal name="button-release-event" handler="on_foreground_color_picker_button_release_event" swapped="no"/>
+                                            <signal name="realize" handler="on_foreground_color_picker_realize" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -1411,6 +1511,8 @@
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
@@ -1419,6 +1521,7 @@
                                 <property name="width_request">238</property>
                                 <property name="height_request">33</property>
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="n_rows">2</property>
                                 <property name="n_columns">14</property>
                                 <property name="column_spacing">1</property>
@@ -1439,8 +1542,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1449,8 +1552,8 @@
                                     <property name="right_attach">12</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1467,8 +1570,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1477,8 +1580,8 @@
                                     <property name="right_attach">11</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1495,8 +1598,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1505,8 +1608,8 @@
                                     <property name="right_attach">10</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1523,8 +1626,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1533,8 +1636,8 @@
                                     <property name="right_attach">9</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1551,8 +1654,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1561,8 +1664,8 @@
                                     <property name="right_attach">8</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1579,8 +1682,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1589,8 +1692,8 @@
                                     <property name="right_attach">7</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1607,8 +1710,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1617,8 +1720,8 @@
                                     <property name="right_attach">6</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1635,8 +1738,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1645,8 +1748,8 @@
                                     <property name="right_attach">5</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1663,8 +1766,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1673,8 +1776,8 @@
                                     <property name="right_attach">4</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1691,8 +1794,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1701,8 +1804,8 @@
                                     <property name="right_attach">3</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1719,8 +1822,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -1729,8 +1832,8 @@
                                     <property name="right_attach">2</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1747,16 +1850,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1773,16 +1876,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">13</property>
                                     <property name="right_attach">14</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1799,16 +1902,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">12</property>
                                     <property name="right_attach">13</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1825,16 +1928,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">11</property>
                                     <property name="right_attach">12</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1851,16 +1954,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">10</property>
                                     <property name="right_attach">11</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1877,16 +1980,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">9</property>
                                     <property name="right_attach">10</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1903,16 +2006,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">8</property>
                                     <property name="right_attach">9</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1929,16 +2032,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">7</property>
                                     <property name="right_attach">8</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1955,16 +2058,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">6</property>
                                     <property name="right_attach">7</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -1981,16 +2084,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">5</property>
                                     <property name="right_attach">6</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -2007,16 +2110,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">4</property>
                                     <property name="right_attach">5</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -2033,16 +2136,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">3</property>
                                     <property name="right_attach">4</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -2059,14 +2162,14 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -2083,16 +2186,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>
                                     <property name="right_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -2109,16 +2212,16 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">2</property>
                                     <property name="right_attach">3</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -2135,8 +2238,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -2145,8 +2248,8 @@
                                     <property name="right_attach">13</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                                 <child>
@@ -2163,8 +2266,8 @@
                                         <property name="can_focus">True</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON1_MOTION_MASK | GDK_BUTTON2_MOTION_MASK | GDK_BUTTON3_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
                                         <property name="extension_events">all</property>
-                                        <signal name="button_press_event" handler="on_color_palette_entry_button_press_event"/>
-                                        <signal name="realize" handler="on_color_palette_entry_realize"/>
+                                        <signal name="button-press-event" handler="on_color_palette_entry_button_press_event" swapped="no"/>
+                                        <signal name="realize" handler="on_color_palette_entry_realize" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -2173,8 +2276,8 @@
                                     <property name="right_attach">14</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"></property>
-                                    <property name="y_options"></property>
+                                    <property name="x_options"/>
+                                    <property name="y_options"/>
                                   </packing>
                                 </child>
                               </object>
@@ -2197,81 +2300,103 @@
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkStatusbar" id="statusbar">
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkHBox" id="hbox4">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkVSeparator" id="vseparator1">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkFrame" id="frame37">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkLabel" id="lb_pos">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="single_line_mode">True</property>
-                        <signal name="realize" handler="on_lb_pos_realize"/>
+                        <signal name="realize" handler="on_lb_pos_realize" swapped="no"/>
                       </object>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVSeparator" id="vseparator3">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkFrame" id="frame3">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkLabel" id="lb_size">
+                        <property name="can_focus">False</property>
                         <property name="single_line_mode">True</property>
-                        <signal name="realize" handler="on_lb_size_realize"/>
+                        <signal name="realize" handler="on_lb_size_realize" swapped="no"/>
                       </object>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVSeparator" id="vseparator2">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">4</property>
                   </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="pack_type">end</property>
                 <property name="position">1</property>
               </packing>
@@ -2279,522 +2404,31 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">2</property>
           </packing>
         </child>
       </object>
     </child>
   </object>
-  <object class="GtkDialog" id="flip_roate_dialog">
-    <property name="width_request">300</property>
-    <property name="height_request">250</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Flip and Rotate</property>
-    <property name="modal">True</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">normal</property>
-    <property name="transient_for">window</property>
-    <property name="has_separator">False</property>
-    <child internal-child="vbox">
-      <object class="GtkVBox" id="flip_and_rotate_vbox1">
-        <property name="visible">True</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child>
-          <object class="GtkFrame" id="flip_and_rotate_frame1">
-            <property name="visible">True</property>
-            <property name="label_xalign">0</property>
-            <child>
-              <object class="GtkAlignment" id="flip_and_rotate_alignment1">
-                <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkTable" id="flip_and_rotate_table1">
-                    <property name="visible">True</property>
-                    <property name="n_rows">6</property>
-                    <property name="n_columns">3</property>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_flip_horizontal">
-                        <property name="label" translatable="yes">_Flip horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="relief">none</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="on_radiobutton_flip_horizontal_toggled"/>
-                      </object>
-                      <packing>
-                        <property name="right_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_flip_vertical">
-                        <property name="label" translatable="yes">Flip _vertical</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_flip_horizontal</property>
-                        <signal name="toggled" handler="on_radiobutton_flip_vertical_toggled"/>
-                      </object>
-                      <packing>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">1</property>
-                        <property name="bottom_attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate">
-                        <property name="label" translatable="yes">_Rotate by angle</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_flip_horizontal</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_toggled"/>
-                      </object>
-                      <packing>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">2</property>
-                        <property name="bottom_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate_90">
-                        <property name="label" translatable="yes">_90&#xB0;</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_90_toggled"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate_180">
-                        <property name="label" translatable="yes">_180&#xB0;</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_rotate_90</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_180_toggled"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate_270">
-                        <property name="label" translatable="yes">_270&#xB0;</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_rotate_90</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_270_toggled"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_dummy1">
-                        <property name="width_request">20</property>
-                        <property name="visible">True</property>
-                      </object>
-                      <packing>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
-                        <property name="x_options">GTK_FILL</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_dummy2">
-                        <property name="width_request">20</property>
-                        <property name="visible">True</property>
-                      </object>
-                      <packing>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
-                        <property name="x_options">GTK_FILL</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_dummy3">
-                        <property name="width_request">20</property>
-                        <property name="visible">True</property>
-                      </object>
-                      <packing>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
-                        <property name="x_options">GTK_FILL</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child type="label">
-              <object class="GtkLabel" id="label_flip_rotate">
-                <property name="visible">True</property>
-                <property name="xalign">0.44999998807907104</property>
-                <property name="yalign">0.47999998927116394</property>
-                <property name="label" translatable="yes">Flip or rotate</property>
-                <property name="use_markup">True</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="flip_and_rotate_action_area1">
-            <property name="visible">True</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="flip_and_rotate_button1">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="flip_and_rotate_button2">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="-5">flip_and_rotate_button1</action-widget>
-      <action-widget response="-6">flip_and_rotate_button2</action-widget>
-    </action-widgets>
-  </object>
   <object class="GtkDialog" id="dialog_attributes">
     <property name="width_request">450</property>
     <property name="height_request">350</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Image Attributes</property>
     <property name="modal">True</property>
     <property name="type_hint">normal</property>
     <property name="transient_for">window</property>
-    <property name="has_separator">False</property>
     <child internal-child="vbox">
       <object class="GtkVBox" id="dialog-attributes_vbox1">
         <property name="visible">True</property>
-        <property name="orientation">vertical</property>
+        <property name="can_focus">False</property>
         <property name="spacing">2</property>
-        <child>
-          <object class="GtkVBox" id="attributes_vbox1">
-            <property name="visible">True</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkTable" id="attributes_table1">
-                <property name="visible">True</property>
-                <property name="n_rows">3</property>
-                <property name="n_columns">2</property>
-                <child>
-                  <object class="GtkLabel" id="attributes_label1">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">File last saved:</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label2">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Not Available</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label3">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Size on disk:</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label4">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Not Available</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label5">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Resolution:</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label6">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Not Available</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkHBox" id="attributes_hbox1">
-                <property name="visible">True</property>
-                <child>
-                  <object class="GtkLabel" id="attributes_label7">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">_Width</property>
-                    <property name="use_underline">True</property>
-                  </object>
-                  <packing>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="attributes_entry1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">&#x25CF;</property>
-                    <signal name="key_press_event" handler="on_attributes_entry_key_press_event"/>
-                  </object>
-                  <packing>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label8">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">_Height</property>
-                    <property name="use_underline">True</property>
-                  </object>
-                  <packing>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="attributes_entry2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">&#x25CF;</property>
-                    <signal name="key_press_event" handler="on_attributes_entry_key_press_event"/>
-                  </object>
-                  <packing>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="attributes_frame1">
-                <property name="visible">True</property>
-                <property name="label_xalign">0</property>
-                <child>
-                  <object class="GtkAlignment" id="attributes_alignment1">
-                    <property name="visible">True</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkHBox" id="attributes_hbox2">
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton1">
-                            <property name="label" translatable="yes">_Inches</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="relief">half</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">attributes_radiobutton3</property>
-                            <signal name="toggled" handler="on_attributes_radiobutton1_toggled"/>
-                          </object>
-                          <packing>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton2">
-                            <property name="label" translatable="yes">C_m</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">attributes_radiobutton3</property>
-                            <signal name="toggled" handler="on_attributes_radiobutton2_toggled"/>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton3">
-                            <property name="label" translatable="yes">_Pixels</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <signal name="toggled" handler="on_attributes_radiobutton3_toggled"/>
-                          </object>
-                          <packing>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="attributes_label9">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Units</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="attributes_frame2">
-                <property name="visible">True</property>
-                <property name="label_xalign">0</property>
-                <child>
-                  <object class="GtkAlignment" id="attributes_alignment2">
-                    <property name="visible">True</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkHBox" id="attributes_hbox3">
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton4">
-                            <property name="label" translatable="yes">_Black and white</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">attributes_radiobutton5</property>
-                          </object>
-                          <packing>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton5">
-                            <property name="label" translatable="yes">Co_lors</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="attributes_label10">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Colors</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="position">3</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkHButtonBox" id="attributes_dialog-action_area1">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="attributes_button1">
@@ -2840,8 +2474,323 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkVBox" id="attributes_vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkTable" id="attributes_table1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="n_rows">3</property>
+                <property name="n_columns">2</property>
+                <child>
+                  <object class="GtkLabel" id="attributes_label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">File last saved:</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Not Available</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Size on disk:</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Not Available</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Resolution:</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label6">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Not Available</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="attributes_hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="attributes_label7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">_Width</property>
+                    <property name="use_underline">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="attributes_entry1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                    <signal name="key-press-event" handler="on_attributes_entry_key_press_event" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label8">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">_Height</property>
+                    <property name="use_underline">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="attributes_entry2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                    <signal name="key-press-event" handler="on_attributes_entry_key_press_event" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="attributes_frame1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkAlignment" id="attributes_alignment1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="attributes_hbox2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton1">
+                            <property name="label" translatable="yes">_Inches</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="relief">half</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">attributes_radiobutton3</property>
+                            <signal name="toggled" handler="on_attributes_radiobutton1_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton2">
+                            <property name="label" translatable="yes">C_m</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">attributes_radiobutton3</property>
+                            <signal name="toggled" handler="on_attributes_radiobutton2_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton3">
+                            <property name="label" translatable="yes">_Pixels</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="on_attributes_radiobutton3_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="attributes_label9">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Units</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="attributes_frame2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkAlignment" id="attributes_alignment2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="attributes_hbox3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton4">
+                            <property name="label" translatable="yes">_Black and white</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">attributes_radiobutton5</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton5">
+                            <property name="label" translatable="yes">Co_lors</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="attributes_label10">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Colors</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -2850,6 +2799,250 @@
       <action-widget response="-5">attributes_button1</action-widget>
       <action-widget response="-6">attributes_button2</action-widget>
       <action-widget response="0">attributes_button3</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkDialog" id="flip_roate_dialog">
+    <property name="width_request">300</property>
+    <property name="height_request">250</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Flip and Rotate</property>
+    <property name="modal">True</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">normal</property>
+    <property name="transient_for">window</property>
+    <child internal-child="vbox">
+      <object class="GtkVBox" id="flip_and_rotate_vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkHButtonBox" id="flip_and_rotate_action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="flip_and_rotate_button1">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="flip_and_rotate_button2">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame" id="flip_and_rotate_frame1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <child>
+              <object class="GtkAlignment" id="flip_and_rotate_alignment1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="left_padding">12</property>
+                <child>
+                  <object class="GtkTable" id="flip_and_rotate_table1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="n_rows">6</property>
+                    <property name="n_columns">3</property>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_flip_horizontal">
+                        <property name="label" translatable="yes">_Flip horizontal</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="relief">none</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_radiobutton_flip_horizontal_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="right_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_flip_vertical">
+                        <property name="label" translatable="yes">Flip _vertical</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_flip_horizontal</property>
+                        <signal name="toggled" handler="on_radiobutton_flip_vertical_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">1</property>
+                        <property name="bottom_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate">
+                        <property name="label" translatable="yes">_Rotate by angle</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_flip_horizontal</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">2</property>
+                        <property name="bottom_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate_90">
+                        <property name="label" translatable="yes">_90°</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_90_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">3</property>
+                        <property name="bottom_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate_180">
+                        <property name="label" translatable="yes">_180°</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_rotate_90</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_180_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate_270">
+                        <property name="label" translatable="yes">_270°</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_rotate_90</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_270_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">5</property>
+                        <property name="bottom_attach">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_dummy1">
+                        <property name="width_request">20</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">3</property>
+                        <property name="bottom_attach">4</property>
+                        <property name="x_options">GTK_FILL</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_dummy2">
+                        <property name="width_request">20</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
+                        <property name="x_options">GTK_FILL</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_dummy3">
+                        <property name="width_request">20</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">5</property>
+                        <property name="bottom_attach">6</property>
+                        <property name="x_options">GTK_FILL</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="label_flip_rotate">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0.44999998807907104</property>
+                <property name="yalign">0.47999998927116394</property>
+                <property name="label" translatable="yes">Flip or rotate</property>
+                <property name="use_markup">True</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">flip_and_rotate_button1</action-widget>
+      <action-widget response="-6">flip_and_rotate_button2</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/data/ui/gnome_paint_yolo.ui
+++ b/data/ui/gnome_paint_yolo.ui
@@ -2,656 +2,6 @@
 <interface>
   <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy toplevel-contextual -->
-  <object class="GtkDialog" id="dialog_attributes">
-    <property name="width_request">450</property>
-    <property name="height_request">350</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Image Attributes</property>
-    <property name="modal">True</property>
-    <property name="type_hint">normal</property>
-    <property name="transient_for">window</property>
-    <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-attributes_vbox1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="attributes_dialog-action_area1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="attributes_button1">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="attributes_button2">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="attributes_button3">
-                <property name="label" translatable="yes">Defaults</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkVBox" id="attributes_vbox1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkTable" id="attributes_table1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="n_rows">3</property>
-                <property name="n_columns">2</property>
-                <child>
-                  <object class="GtkLabel" id="attributes_label1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">File last saved:</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Not Available</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Size on disk:</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Not Available</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label5">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Resolution:</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label6">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Not Available</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkHBox" id="attributes_hbox1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="attributes_label7">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">_Width</property>
-                    <property name="use_underline">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="attributes_entry1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
-                    <signal name="key-press-event" handler="on_attributes_entry_key_press_event" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="attributes_label8">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">_Height</property>
-                    <property name="use_underline">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="attributes_entry2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
-                    <signal name="key-press-event" handler="on_attributes_entry_key_press_event" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="attributes_frame1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label_xalign">0</property>
-                <child>
-                  <object class="GtkAlignment" id="attributes_alignment1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkHBox" id="attributes_hbox2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton1">
-                            <property name="label" translatable="yes">_Inches</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_action_appearance">False</property>
-                            <property name="relief">half</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">attributes_radiobutton3</property>
-                            <signal name="toggled" handler="on_attributes_radiobutton1_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton2">
-                            <property name="label" translatable="yes">C_m</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_action_appearance">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">attributes_radiobutton3</property>
-                            <signal name="toggled" handler="on_attributes_radiobutton2_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton3">
-                            <property name="label" translatable="yes">_Pixels</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_action_appearance">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <signal name="toggled" handler="on_attributes_radiobutton3_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="attributes_label9">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Units</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="attributes_frame2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label_xalign">0</property>
-                <child>
-                  <object class="GtkAlignment" id="attributes_alignment2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkHBox" id="attributes_hbox3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton4">
-                            <property name="label" translatable="yes">_Black and white</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_action_appearance">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">attributes_radiobutton5</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="attributes_radiobutton5">
-                            <property name="label" translatable="yes">Co_lors</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_action_appearance">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="attributes_label10">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Colors</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="-5">attributes_button1</action-widget>
-      <action-widget response="-6">attributes_button2</action-widget>
-      <action-widget response="0">attributes_button3</action-widget>
-    </action-widgets>
-  </object>
-  <object class="GtkDialog" id="flip_roate_dialog">
-    <property name="width_request">300</property>
-    <property name="height_request">250</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Flip and Rotate</property>
-    <property name="modal">True</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">normal</property>
-    <property name="transient_for">window</property>
-    <child internal-child="vbox">
-      <object class="GtkVBox" id="flip_and_rotate_vbox1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="flip_and_rotate_action_area1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="flip_and_rotate_button1">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="flip_and_rotate_button2">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkFrame" id="flip_and_rotate_frame1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
-            <child>
-              <object class="GtkAlignment" id="flip_and_rotate_alignment1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkTable" id="flip_and_rotate_table1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="n_rows">6</property>
-                    <property name="n_columns">3</property>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_flip_horizontal">
-                        <property name="label" translatable="yes">_Flip horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
-                        <property name="relief">none</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="on_radiobutton_flip_horizontal_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="right_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_flip_vertical">
-                        <property name="label" translatable="yes">Flip _vertical</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_flip_horizontal</property>
-                        <signal name="toggled" handler="on_radiobutton_flip_vertical_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">1</property>
-                        <property name="bottom_attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate">
-                        <property name="label" translatable="yes">_Rotate by angle</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_flip_horizontal</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">2</property>
-                        <property name="bottom_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate_90">
-                        <property name="label" translatable="yes">_90°</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_90_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate_180">
-                        <property name="label" translatable="yes">_180°</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_rotate_90</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_180_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="radiobutton_rotate_270">
-                        <property name="label" translatable="yes">_270°</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">radiobutton_rotate_90</property>
-                        <signal name="toggled" handler="on_radiobutton_rotate_270_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_dummy1">
-                        <property name="width_request">20</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
-                        <property name="x_options">GTK_FILL</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_dummy2">
-                        <property name="width_request">20</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
-                        <property name="x_options">GTK_FILL</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_dummy3">
-                        <property name="width_request">20</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
-                        <property name="x_options">GTK_FILL</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child type="label">
-              <object class="GtkLabel" id="label_flip_rotate">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0.44999998807907104</property>
-                <property name="yalign">0.47999998927116394</property>
-                <property name="label" translatable="yes">Flip or rotate</property>
-                <property name="use_markup">True</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="-5">flip_and_rotate_button1</action-widget>
-      <action-widget response="-6">flip_and_rotate_button2</action-widget>
-    </action-widgets>
-  </object>
   <object class="GtkWindow" id="window">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -671,7 +21,6 @@
               <object class="GtkMenuItem" id="menuitem-file">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">_File</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
@@ -684,7 +33,6 @@
                         <property name="label">gtk-new</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="n" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -696,7 +44,6 @@
                         <property name="label">gtk-open</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="o" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -708,7 +55,6 @@
                         <property name="label">gtk-save</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -720,7 +66,6 @@
                         <property name="label">gtk-save-as</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="s" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
@@ -742,7 +87,6 @@
                         <property name="extension_events">all</property>
                         <property name="has_tooltip">True</property>
                         <property name="border_width">2</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="q" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -757,7 +101,6 @@
               <object class="GtkMenuItem" id="menuitem-edit">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">_Edit</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
@@ -769,7 +112,6 @@
                         <property name="label">gtk-undo</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="z" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -781,7 +123,6 @@
                         <property name="label">gtk-redo</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="z" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
@@ -799,7 +140,6 @@
                         <property name="label">gtk-cut</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="x" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -810,7 +150,6 @@
                         <property name="label">gtk-copy</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="c" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -822,7 +161,6 @@
                         <property name="label">gtk-paste</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="v" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -834,7 +172,6 @@
                         <property name="label">gtk-delete</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <accelerator key="Delete" signal="activate"/>
@@ -848,7 +185,6 @@
               <object class="GtkMenuItem" id="menuitem5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">_Image</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
@@ -859,7 +195,6 @@
                       <object class="GtkMenuItem" id="menu_flip_rotate">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">_Flip/Rotate...</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="on_menu_flip_rotate_activate" swapped="no"/>
@@ -869,7 +204,6 @@
                       <object class="GtkMenuItem" id="menu_invert_colors">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">_Invert Colors</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="on_menu_invert_colors_activate" swapped="no"/>
@@ -879,7 +213,6 @@
                       <object class="GtkMenuItem" id="menu_clear_image">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">_Clear Image</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="on_menu_clear_image_activate" swapped="no"/>
@@ -889,7 +222,6 @@
                       <object class="GtkCheckMenuItem" id="menu_draw_opaque">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="label" translatable="yes">_Draw Opaque</property>
                         <property name="use_underline">True</property>
                         <property name="active">True</property>
@@ -904,7 +236,6 @@
               <object class="GtkMenuItem" id="menuitem_help">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="label" translatable="yes">_Help</property>
                 <property name="use_underline">True</property>
                 <child type="submenu">
@@ -916,7 +247,6 @@
                         <property name="label">gtk-about</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="on_menu_about_activate" swapped="no"/>
@@ -965,7 +295,6 @@
                               <object class="GtkRadioToolButton" id="tool-free-select">
                                 <property name="can_focus">True</property>
                                 <property name="tooltip_text" translatable="yes">Free select tool</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_free_select_toggled" swapped="no"/>
                               </object>
@@ -978,7 +307,6 @@
                               <object class="GtkRadioToolButton" id="tool-eraser">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-eraser</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_eraser_toggled" swapped="no"/>
@@ -992,7 +320,6 @@
                               <object class="GtkRadioToolButton" id="tool-color-picker">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-color-picker</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_color_picker_toggled" swapped="no"/>
@@ -1005,7 +332,6 @@
                             <child>
                               <object class="GtkRadioToolButton" id="tool-pencil">
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-pencil</property>
                                 <property name="active">True</property>
                                 <property name="group">tool-free-select</property>
@@ -1021,7 +347,6 @@
                               <object class="GtkRadioToolButton" id="tool-airbrush">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-airbrush</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_airbrush_toggled" swapped="no"/>
@@ -1035,7 +360,6 @@
                               <object class="GtkRadioToolButton" id="draw-line">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock_draw-line</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_draw_line_toggled" swapped="no"/>
@@ -1049,7 +373,6 @@
                               <object class="GtkRadioToolButton" id="draw-rectangle">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock_draw-rectangle</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_draw_rectangle_toggled" swapped="no"/>
@@ -1063,7 +386,6 @@
                               <object class="GtkRadioToolButton" id="draw-ellipse">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock_draw-ellipse</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_draw_ellipse_toggled" swapped="no"/>
@@ -1093,7 +415,6 @@
                               <object class="GtkRadioToolButton" id="tool-rect-select">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-rect-select</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_rect_select_toggled" swapped="no"/>
@@ -1107,7 +428,6 @@
                               <object class="GtkRadioToolButton" id="tool-bucket-fill">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-bucket-fill</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_bucket_fill_toggled" swapped="no"/>
@@ -1121,7 +441,6 @@
                               <object class="GtkRadioToolButton" id="tool-zoom">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-zoom</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_zoom_toggled" swapped="no"/>
@@ -1135,7 +454,6 @@
                               <object class="GtkRadioToolButton" id="tool-paintbrush">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-paintbrush</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_paintbrush_toggled" swapped="no"/>
@@ -1149,7 +467,6 @@
                               <object class="GtkRadioToolButton" id="tool-text">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock-tool-text</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_tool_text_toggled" swapped="no"/>
@@ -1163,7 +480,6 @@
                               <object class="GtkRadioToolButton" id="draw-curve">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock_draw-curve</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_draw_curve_toggled" swapped="no"/>
@@ -1177,7 +493,6 @@
                               <object class="GtkRadioToolButton" id="draw-polygon">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock_draw-fill_polygon</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_draw_polygon_toggled" swapped="no"/>
@@ -1191,7 +506,6 @@
                               <object class="GtkRadioToolButton" id="draw-rounded-rectangle">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="use_action_appearance">False</property>
                                 <property name="icon_name">stock_draw-rounded-rectangle</property>
                                 <property name="group">tool-free-select</property>
                                 <signal name="toggled" handler="on_draw_rounded_rectangle_toggled" swapped="no"/>
@@ -1258,7 +572,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="sel1">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="active">True</property>
                                         <signal name="toggled" handler="on_sel1_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_sel1_realize" swapped="no"/>
@@ -1271,7 +584,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="sel2">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">sel1</property>
                                         <signal name="toggled" handler="on_sel2_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_sel2_realize" swapped="no"/>
@@ -1321,7 +633,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="rect0">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="active">True</property>
                                         <signal name="toggled" handler="on_rect0_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_rect0_realize" swapped="no"/>
@@ -1334,7 +645,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="rect1">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">rect0</property>
                                         <signal name="toggled" handler="on_rect1_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_rect1_realize" swapped="no"/>
@@ -1347,7 +657,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="rect2">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">rect0</property>
                                         <signal name="toggled" handler="on_rect2_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_rect2_realize" swapped="no"/>
@@ -1384,7 +693,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="line0">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="active">True</property>
                                         <signal name="toggled" handler="on_line0_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_line0_realize" swapped="no"/>
@@ -1397,7 +705,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="line1">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">line0</property>
                                         <signal name="toggled" handler="on_line1_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_line1_realize" swapped="no"/>
@@ -1410,7 +717,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="line2">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">line0</property>
                                         <signal name="toggled" handler="on_line2_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_line2_realize" swapped="no"/>
@@ -1423,7 +729,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="line3">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">line0</property>
                                         <signal name="toggled" handler="on_line3_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_line3_realize" swapped="no"/>
@@ -1436,7 +741,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="line4">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">line0</property>
                                         <signal name="toggled" handler="on_line4_toggled" swapped="no"/>
                                         <signal name="realize" handler="on_line4_realize" swapped="no"/>
@@ -1486,7 +790,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase0">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="active">True</property>
                                         <signal name="realize" handler="on_erase0_realize" swapped="no"/>
                                       </object>
@@ -1498,7 +801,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase1">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">erase0</property>
                                         <signal name="realize" handler="on_erase1_realize" swapped="no"/>
                                       </object>
@@ -1510,7 +812,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase2">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">erase0</property>
                                         <signal name="realize" handler="on_erase2_realize" swapped="no"/>
                                       </object>
@@ -1522,7 +823,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="erase3">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">erase0</property>
                                         <signal name="realize" handler="on_erase3_realize" swapped="no"/>
                                       </object>
@@ -1570,7 +870,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom0">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="active">True</property>
                                       </object>
                                       <packing>
@@ -1581,7 +880,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom1">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">zoom0</property>
                                       </object>
                                       <packing>
@@ -1592,7 +890,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom2">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">zoom0</property>
                                       </object>
                                       <packing>
@@ -1603,7 +900,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="zoom3">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">zoom0</property>
                                       </object>
                                       <packing>
@@ -1652,7 +948,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush0">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="active">True</property>
                                             <signal name="realize" handler="on_brush0_realize" swapped="no"/>
                                           </object>
@@ -1664,7 +959,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush1">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush1_realize" swapped="no"/>
                                           </object>
@@ -1676,7 +970,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush2">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush2_realize" swapped="no"/>
                                           </object>
@@ -1702,7 +995,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush3">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="active">True</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush3_realize" swapped="no"/>
@@ -1715,7 +1007,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush4">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush4_realize" swapped="no"/>
                                           </object>
@@ -1727,7 +1018,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush5">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush5_realize" swapped="no"/>
                                           </object>
@@ -1753,7 +1043,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush6">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush6_realize" swapped="no"/>
                                           </object>
@@ -1765,7 +1054,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush7">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush7_realize" swapped="no"/>
                                           </object>
@@ -1777,7 +1065,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush8">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush8_realize" swapped="no"/>
                                           </object>
@@ -1803,7 +1090,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush9">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush9_realize" swapped="no"/>
                                           </object>
@@ -1815,7 +1101,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush10">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush10_realize" swapped="no"/>
                                           </object>
@@ -1827,7 +1112,6 @@
                                         <child>
                                           <object class="GtkRadioToolButton" id="brush11">
                                             <property name="can_focus">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="group">brush0</property>
                                             <signal name="realize" handler="on_brush11_realize" swapped="no"/>
                                           </object>
@@ -1882,7 +1166,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="spray0">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="active">True</property>
                                       </object>
                                       <packing>
@@ -1893,7 +1176,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="spray1">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">spray0</property>
                                       </object>
                                       <packing>
@@ -1904,7 +1186,6 @@
                                     <child>
                                       <object class="GtkRadioToolButton" id="spray2">
                                         <property name="can_focus">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="group">spray0</property>
                                       </object>
                                       <packing>
@@ -2106,15 +1387,11 @@
                                 </child>
                                 <child>
                                   <object class="GtkFixed" id="cv_fixed">
-                                    <property name="width_request">300</property>
-                                    <property name="height_request">300</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <signal name="realize" handler="on_cv_fixed_realize" swapped="no"/>
                                     <child>
                                       <object class="GtkDrawingArea" id="cv_drawing">
-                                        <property name="width_request">100</property>
-                                        <property name="height_request">80</property>
                                         <property name="can_focus">False</property>
                                         <property name="events">GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_STRUCTURE_MASK</property>
                                         <signal name="button-press-event" handler="on_cv_drawing_button_press_event" swapped="no"/>
@@ -2132,8 +1409,8 @@
                                     <property name="right_attach">2</property>
                                     <property name="top_attach">1</property>
                                     <property name="bottom_attach">2</property>
-                                    <property name="x_options"/>
-                                    <property name="y_options"/>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
                                   </packing>
                                 </child>
                               </object>
@@ -3133,5 +2410,639 @@
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkDialog" id="dialog_attributes">
+    <property name="width_request">450</property>
+    <property name="height_request">350</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Image Attributes</property>
+    <property name="modal">True</property>
+    <property name="type_hint">normal</property>
+    <property name="transient_for">window</property>
+    <child internal-child="vbox">
+      <object class="GtkVBox" id="dialog-attributes_vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkHButtonBox" id="attributes_dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="attributes_button1">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="attributes_button2">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="attributes_button3">
+                <property name="label" translatable="yes">Defaults</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkVBox" id="attributes_vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkTable" id="attributes_table1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="n_rows">3</property>
+                <property name="n_columns">2</property>
+                <child>
+                  <object class="GtkLabel" id="attributes_label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">File last saved:</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Not Available</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Size on disk:</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Not Available</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Resolution:</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label6">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Not Available</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="attributes_hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="attributes_label7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">_Width</property>
+                    <property name="use_underline">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="attributes_entry1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                    <signal name="key-press-event" handler="on_attributes_entry_key_press_event" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="attributes_label8">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">_Height</property>
+                    <property name="use_underline">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="attributes_entry2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                    <signal name="key-press-event" handler="on_attributes_entry_key_press_event" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="attributes_frame1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkAlignment" id="attributes_alignment1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="attributes_hbox2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton1">
+                            <property name="label" translatable="yes">_Inches</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="relief">half</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">attributes_radiobutton3</property>
+                            <signal name="toggled" handler="on_attributes_radiobutton1_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton2">
+                            <property name="label" translatable="yes">C_m</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">attributes_radiobutton3</property>
+                            <signal name="toggled" handler="on_attributes_radiobutton2_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton3">
+                            <property name="label" translatable="yes">_Pixels</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="on_attributes_radiobutton3_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="attributes_label9">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Units</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="attributes_frame2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkAlignment" id="attributes_alignment2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="attributes_hbox3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton4">
+                            <property name="label" translatable="yes">_Black and white</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">attributes_radiobutton5</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="attributes_radiobutton5">
+                            <property name="label" translatable="yes">Co_lors</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="attributes_label10">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Colors</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">attributes_button1</action-widget>
+      <action-widget response="-6">attributes_button2</action-widget>
+      <action-widget response="0">attributes_button3</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkDialog" id="flip_roate_dialog">
+    <property name="width_request">300</property>
+    <property name="height_request">250</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Flip and Rotate</property>
+    <property name="modal">True</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">normal</property>
+    <property name="transient_for">window</property>
+    <child internal-child="vbox">
+      <object class="GtkVBox" id="flip_and_rotate_vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkHButtonBox" id="flip_and_rotate_action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="flip_and_rotate_button1">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="flip_and_rotate_button2">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame" id="flip_and_rotate_frame1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <child>
+              <object class="GtkAlignment" id="flip_and_rotate_alignment1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="left_padding">12</property>
+                <child>
+                  <object class="GtkTable" id="flip_and_rotate_table1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="n_rows">6</property>
+                    <property name="n_columns">3</property>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_flip_horizontal">
+                        <property name="label" translatable="yes">_Flip horizontal</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="relief">none</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_radiobutton_flip_horizontal_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="right_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_flip_vertical">
+                        <property name="label" translatable="yes">Flip _vertical</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_flip_horizontal</property>
+                        <signal name="toggled" handler="on_radiobutton_flip_vertical_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">1</property>
+                        <property name="bottom_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate">
+                        <property name="label" translatable="yes">_Rotate by angle</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_flip_horizontal</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">2</property>
+                        <property name="bottom_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate_90">
+                        <property name="label" translatable="yes">_90°</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_90_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">3</property>
+                        <property name="bottom_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate_180">
+                        <property name="label" translatable="yes">_180°</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_rotate_90</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_180_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_rotate_270">
+                        <property name="label" translatable="yes">_270°</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_rotate_90</property>
+                        <signal name="toggled" handler="on_radiobutton_rotate_270_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">3</property>
+                        <property name="top_attach">5</property>
+                        <property name="bottom_attach">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_dummy1">
+                        <property name="width_request">20</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">3</property>
+                        <property name="bottom_attach">4</property>
+                        <property name="x_options">GTK_FILL</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_dummy2">
+                        <property name="width_request">20</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
+                        <property name="x_options">GTK_FILL</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_dummy3">
+                        <property name="width_request">20</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">5</property>
+                        <property name="bottom_attach">6</property>
+                        <property name="x_options">GTK_FILL</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="label_flip_rotate">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0.44999998807907104</property>
+                <property name="yalign">0.47999998927116394</property>
+                <property name="label" translatable="yes">Flip or rotate</property>
+                <property name="use_markup">True</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">flip_and_rotate_button1</action-widget>
+      <action-widget response="-6">flip_and_rotate_button2</action-widget>
+    </action-widgets>
   </object>
 </interface>

--- a/src/cv_text_tool.c
+++ b/src/cv_text_tool.c
@@ -108,7 +108,7 @@ tool_text_init ( gp_canvas * canvas )
     m_priv->text_view           = GTK_TEXT_VIEW(gtk_text_view_new());
 
     gtk_fixed_put(cv_fixed, GTK_WIDGET(m_priv->text_view), 0, 0);
-    gtk_widget_set_size_request(GTK_WIDGET(m_priv->text_view), 300, 300);
+    gtk_widget_set_size_request(GTK_WIDGET(m_priv->text_view), GTK_WIDGET(cv_fixed)->allocation.width, GTK_WIDGET(cv_fixed)->allocation.height);
     struct textview_impl_priv *japan =
         (struct textview_impl_priv *)m_priv->text_view->text_window;
 //    gdk_window_set_composited(japan->bin_window, TRUE);

--- a/src/cv_text_tool.c
+++ b/src/cv_text_tool.c
@@ -42,6 +42,7 @@ typedef struct {
 	gp_tool			tool;
 	gp_canvas       *cv;
     GtkTextView     *text_view;
+    GtkTextMark     *start_text_mark;
 } private_data;
 
 /* GDK private stuff hack */
@@ -53,13 +54,6 @@ struct textview_impl_priv {
     // There is some extra data here we don't care about
 
 };
-
-/* Signal handeler to parrent GDK window hack */
-static gboolean 
-draw_text_only(GdkWindow *bin, GdkEventExpose *event)
-{
-    return FALSE;
-}
 
 /*Member functions*/
 
@@ -94,6 +88,30 @@ destroy_private_data( void )
 	m_priv = NULL;
 }
 
+/* Signal handeler to unfuck scrolling when textview grows too big */
+static gboolean 
+unfuck_scroll(GtkTextView *textview, ...)
+{
+    fprintf(stderr, "in unfuck_scroll");
+    if(m_priv == NULL)
+        return FALSE;
+    struct textview_impl_priv *japan =
+        (struct textview_impl_priv *)m_priv->text_view->text_window;
+
+        gdk_window_invalidate_rect(japan->bin_window, NULL, FALSE);
+        gdk_window_process_updates(japan->bin_window, FALSE);
+        // gtk_text_buffer_place_cursor(gtk_text_view_get_buffer(m_priv->text_view), m_priv->start_iter)
+//    gtk_text_view_scroll_to_mark (m_priv->text_view,
+//                                  m_priv->start_text_mark,
+//                                  0.0,
+//                                  TRUE,
+//                                  0.0,
+///                                  0.0);
+    return FALSE;
+}
+
+
+
 gp_tool * 
 tool_text_init ( gp_canvas * canvas )
 {
@@ -106,27 +124,28 @@ tool_text_init ( gp_canvas * canvas )
 	m_priv->tool.reset			= reset;
 	m_priv->tool.destroy		= destroy;
     m_priv->text_view           = GTK_TEXT_VIEW(gtk_text_view_new());
+    m_priv->start_text_mark     = gtk_text_mark_new("japan", FALSE);
 
     gtk_fixed_put(cv_fixed, GTK_WIDGET(m_priv->text_view), 0, 0);
     gtk_widget_set_size_request(GTK_WIDGET(m_priv->text_view), GTK_WIDGET(cv_fixed)->allocation.width, GTK_WIDGET(cv_fixed)->allocation.height);
     struct textview_impl_priv *japan =
         (struct textview_impl_priv *)m_priv->text_view->text_window;
-//    gdk_window_set_composited(japan->bin_window, TRUE);
-    GError *errz = NULL;
-    GdkPixbuf *bg = gdk_pixbuf_new_from_file("/home/andrew/Desktop/japan.jpg", &errz);
-    if(!bg)
-        fprintf(stderr, "PAYATTENTION WATERLO!");
-            
-
-//     g_signal_connect_after (japan->window, "expose-event",
-//                                       G_CALLBACK (draw_text_only), NULL);
-
- 
- GdkPixmap *japans = gdk_pixmap_new(NULL, 5, 5, 32);
- gdk_draw_pixbuf(japans, NULL, bg, 0, 0, 0, 0, -1, -1, GDK_RGB_DITHER_NONE, 0, 0); 
  gdk_window_set_back_pixmap(japan->bin_window, m_priv->cv->pixmap, FALSE);
 
     gtk_widget_show(GTK_WIDGET(m_priv->text_view));
+
+    GtkTextBuffer *japan_text_buf = gtk_text_view_get_buffer(m_priv->text_view);
+    GtkTextIter start_iter;
+    gtk_text_buffer_get_iter_at_offset (japan_text_buf, &start_iter, 7);
+    gtk_text_buffer_add_mark(japan_text_buf, m_priv->start_text_mark, &start_iter);
+
+    gtk_text_view_set_wrap_mode(m_priv->text_view, GTK_WRAP_CHAR);
+
+ g_signal_connect_after (m_priv->text_view, "event",
+                            G_CALLBACK (unfuck_scroll), NULL);
+
+
+ 
 	return &m_priv->tool;
 }
 
@@ -241,7 +260,18 @@ destroy ( gpointer data  )
 {
 	g_print("text tool destroy\n");
     gtk_widget_queue_draw ( m_priv->cv->widget );
-	destroy_private_data ();
+    struct textview_impl_priv *japan =
+        (struct textview_impl_priv *)m_priv->text_view->text_window;
+    gdk_window_redirect_to_drawable(japan->bin_window, m_priv->cv->pixmap, 0, 0, 0, 0, -1, -1);
+    gtk_text_view_set_cursor_visible(m_priv->text_view, FALSE);
+    unfuck_scroll(NULL);
+    //gtk_widget_hide(GTK_WIDGET(m_priv->text_view));
+    //gtk_fixed_move(cv_fixed, GTK_WIDGET(m_priv->text_view), 9899999, 999999);
+    gtk_widget_destroy(GTK_WIDGET(m_priv->text_view));
+    gtk_widget_queue_draw(m_priv->cv->widget);
+	gdk_window_process_updates (gtk_widget_get_parent_window(m_priv->cv->widget), FALSE);
+   // g_object_unref(m_priv->text_view);
+	destroy_private_data();
 }
 
 

--- a/src/cv_text_tool.c
+++ b/src/cv_text_tool.c
@@ -33,6 +33,10 @@
 #include "selection.h"
 #include "gp-image.h"
 
+
+/* The container over the canvas which the text box will be inserted into */
+static GtkFixed *cv_fixed;
+
 /*private data*/
 typedef struct {
 	gp_tool			tool;
@@ -84,11 +88,17 @@ tool_text_init ( gp_canvas * canvas )
 	m_priv->tool.draw			= draw;
 	m_priv->tool.reset			= reset;
 	m_priv->tool.destroy		= destroy;
-
     // m_priv->text_view           = gtk_text_view_new
 	
 	return &m_priv->tool;
 }
+
+void 
+on_cv_fixed_realize(GtkWidget *fixed, gpointer user_data)
+{
+    cv_fixed = fixed;
+}
+
 
 static gboolean
 button_press ( GdkEventButton *event )
@@ -186,7 +196,7 @@ draw ( void )
 static void 
 reset ( void )
 {
-    set_cursor ( GDK_DOTBOX );
+    set_cursor ( GDK_XTERM );
 }
 
 static void 
@@ -201,7 +211,7 @@ destroy ( gpointer data  )
 static void 
 set_cursor ( GdkCursorType cursor_type )
 {
-    /* static GdkCursorType last_cursor = GDK_LAST_CURSOR;
+    static GdkCursorType last_cursor = GDK_LAST_CURSOR;
     if ( cursor_type != last_cursor )
     {
         GdkCursor *cursor = gdk_cursor_new ( cursor_type );
@@ -209,7 +219,7 @@ set_cursor ( GdkCursorType cursor_type )
 	    gdk_window_set_cursor ( m_priv->cv->drawing, cursor );
 	    gdk_cursor_unref( cursor );
         last_cursor = cursor_type;
-    } */
+    }
 }
 
 static void 
@@ -232,17 +242,16 @@ set_point ( GdkPoint *p )
 static void 
 change_cursor ( GdkPoint *p )
 {
-    /* 
     GdkCursorType cursor;
     cursor = gp_selection_get_cursor ( p );
     if ( cursor == GDK_BLANK_CURSOR ) 
     {
-        set_cursor ( GDK_DOTBOX );
+        set_cursor ( GDK_XTERM );
     }
     else
     {
         set_cursor ( cursor );
-    } */
+    }
 }
 
 

--- a/src/cv_text_tool.c
+++ b/src/cv_text_tool.c
@@ -148,6 +148,7 @@ on_cv_fixed_realize(GtkWidget *fixed, gpointer user_data)
 static gboolean
 button_press ( GdkEventButton *event )
 {
+    // TODO: This was from rect_select. What do we even do here?
     /* GdkPoint p;
     p.x = (gint)event->x;
     p.y = (gint)event->y;
@@ -185,6 +186,7 @@ button_press ( GdkEventButton *event )
 static gboolean
 button_release ( GdkEventButton *event )
 {
+    // TODO: This was from rect_select. What do we even do here?
     /* if ( event->type == GDK_BUTTON_RELEASE )
     {
         if ( m_priv->state == SEL_DRAWING )
@@ -204,6 +206,7 @@ button_release ( GdkEventButton *event )
 static gboolean
 button_motion ( GdkEventMotion *event )
 {
+    // TODO: This was from rect_select. What do we even do here?
     /*
     GdkPoint p;
     p.x = (gint)event->x;
@@ -235,6 +238,7 @@ button_motion ( GdkEventMotion *event )
 static void
 draw ( void )
 {
+    // TODO: This was from rect_select. What do we even do here?
     /* gp_selection_draw (NULL); */
 }
 
@@ -281,6 +285,7 @@ set_cursor ( GdkCursorType cursor_type )
 static void
 set_point ( GdkPoint *p )
 {
+    // TODO: This was from rect_select. What do we even do here?
     /*
     gint x1,y1;
     GdkRectangle rect;


### PR DESCRIPTION
- Use the cursor type GDK_XTERM which is the text tool "I" looking cursor.
- Initialize cv_fixed
- Modified ui file so that the table wraps the fixed container properly
